### PR TITLE
Removes [_1]..[_2] from fail_with() output

### DIFF
--- a/lib/Mojolicious/Plugin/I18N.pm
+++ b/lib/Mojolicious/Plugin/I18N.pm
@@ -152,8 +152,10 @@ sub languages {
 		$handle->fail_with(sub {
 			my $self = shift;
 			my $text = shift;
+			my $i = 0;
 			foreach (@_){
-				$text =~ s/\[_\d+\]/$_/;
+				$i++;
+				$text =~ s/\[_$i\]/$_/g;
 			}
 			return $text;
 		});


### PR DESCRIPTION
Fixes an issue with fail_with() subroutine when template uses line parameters for a string, but no key in %Lexicon is found:
Was:
<h1>[% c.l("Main [_1] Page [_1]",1,2) %]</h1> => Main [_1] Page [_1]
Is:
<h1>[% c.l("Main [_1] Page [_1]",1,2) %]</h1> => Main 1 Page 2
