### PR TITLE
Fix loading default language

### DIFF
--- a/lib/Mojolicious/Plugin/I18N.pm
+++ b/lib/Mojolicious/Plugin/I18N.pm
@@ -196,7 +196,7 @@ sub _load_module {
 			eval qq(require "$file.pm");
 		
 			my $default = $self->{default};
-			if ($@ || eval "\%${module}::Lexicon") {
+			if ($@ || not eval "\%${module}::Lexicon") {
 				if ($_ eq $default) {
 					DEBUG && warn("Create the I18N class $module");
 					

--- a/t/App/I18N/es.pm
+++ b/t/App/I18N/es.pm
@@ -1,0 +1,6 @@
+package App::I18N::es;
+use Mojo::Base 'App::I18N';
+
+our %Lexicon = (_AUTO => 1, hello => 'hola');
+
+1;

--- a/t/i18n_default_fallback.t
+++ b/t/i18n_default_fallback.t
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+use lib qw(t lib ../lib ../mojo/lib ../../mojo/lib);
+use Mojo::Base -strict;
+
+# Disable Bonjour, IPv6 and libev
+BEGIN {
+  $ENV{MOJO_NO_BONJOUR} = $ENV{MOJO_NO_IPV6} = 1;
+  $ENV{MOJO_IOWATCHER} = 'Mojo::IOWatcher';
+}
+
+use Test::More tests => 3;
+use Test::Mojo;
+use Mojolicious::Lite;
+
+# I18N plugin
+plugin I18N => { namespace => 'App::I18N', default => 'es' };
+
+# GET /
+get '/' => 'index';
+
+my $t = Test::Mojo->new;
+
+# Falling back to default with a lexicon defined
+$t->get_ok('/' => { 'Accept-Language' => 'de' })->status_is(200)
+  ->content_is("holaes\n");
+
+__DATA__
+@@ index.html.ep
+<%=l 'hello' %><%= languages %>


### PR DESCRIPTION
When requesting (or falling back to) default language, its package/lexicon definition gets overridden.
