### PR TITLE
Process name of default language

### DIFF
--- a/lib/Mojolicious/Plugin/I18N.pm
+++ b/lib/Mojolicious/Plugin/I18N.pm
@@ -15,6 +15,8 @@ sub register {
 	# Initialize
 	my $namespace = $conf->{namespace} || ( (ref $app) . '::I18N' );
 	my $default   = $conf->{default  } || 'en';
+	$default =~ tr/-A-Z/_a-z/;
+	$default =~ tr/_a-z0-9//cd;
 	my $langs     = $conf->{support_url_langs};
 	my $hosts     = $conf->{support_hosts    };
 	

--- a/t/i18n_app_en_us.t
+++ b/t/i18n_app_en_us.t
@@ -1,0 +1,47 @@
+#!/usr/bin/env perl
+use lib qw(t lib ../lib ../mojo/lib ../../mojo/lib);
+use utf8;
+
+use Mojo::Base -base;
+
+# Disable Bonjour, IPv6 and libev
+BEGIN {
+  $ENV{MOJO_NO_BONJOUR} = $ENV{MOJO_NO_IPV6} = 1;
+  $ENV{MOJO_IOWATCHER} = 'Mojo::IOWatcher';
+}
+
+use Test::More tests => 17;
+
+use Mojolicious::Lite;
+
+use Test::Mojo;
+
+# I18N plugin
+plugin 'I18N' => { namespace => 'App::I18N', default => 'Приветen-US', support_url_langs => [qw(ru en de en-us)] };
+
+get '/' => 'index';
+
+#
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/')->status_is(200)
+  ->content_is("helloHello two USen-us\n");
+
+$t->get_ok('/ru')->status_is(200)
+  ->content_is("ПриветПривет дваru\n");
+
+$t->get_ok('/en')->status_is(200)
+  ->content_is("helloHello twoen\n");
+
+$t->get_ok('/de')->status_is(200)
+  ->content_is("helloHello two USen-us\n");
+
+$t->get_ok('/en-us')->status_is(200)
+  ->content_is("helloHello two USen-us\n");
+
+$t->get_ok('/es')->status_is(404);
+
+__DATA__
+@@ index.html.ep
+<%=l 'hello' %><%=l 'hello2' %><%= languages %>


### PR DESCRIPTION
The plugin crashes when default language is set in the way described in Perldoc 
(http://perldoc.perl.org/Locale/Maketext.html#LANGUAGE-CLASS-HIERARCHIES) or similar to the support_url_langs used in the tests. For example: "en-US".
