### PR TITLE
tests and fix for handling the fail_with handler

### DIFF
--- a/lib/Mojolicious/Plugin/I18N.pm
+++ b/lib/Mojolicious/Plugin/I18N.pm
@@ -154,7 +154,7 @@ sub languages {
 	$self->_load_module($namespace => $_) for @languages;
 	
 	if (my $handle = $namespace->get_handle(@languages)) {
-		$handle->fail_with(sub { $_[1] });
+		#$handle->fail_with(sub { $_[1] });
 		$self->{handle}   = $handle;
 		$self->{language} = $handle->language_tag;
 	}

--- a/t/App/I18N.pm
+++ b/t/App/I18N.pm
@@ -1,15 +1,31 @@
 package App::I18N;
 use base 'Locale::Maketext';
 
+sub init {
+  my $lh = $_[0];  # a newborn handle
+  
+  $lh->SUPER::init();
+  $lh->fail_with('fail_handler');  
+  return;
+}
+
+sub fail_handler{
+  my ($failing_lh, $key, $params) = @_;
+  
+  return "failed_$key";
+}
+
 package App::I18N::ru;
 use Mojo::Base 'App::I18N';
 use utf8;
 
-our %Lexicon = (hello => 'Привет', hello2 => 'Привет два');
+our %Lexicon = ( _AUTO => 0, hello => 'Привет', hello2 => 'Привет два');
 
 package App::I18N::en;
 use Mojo::Base 'App::I18N';
 
-our %Lexicon = (_AUTO => 1, hello2 => 'Hello two');
+our %Lexicon = (_AUTO => 0, hello2 => 'Hello two');
+
+
 
 1;

--- a/t/i18n_app.t
+++ b/t/i18n_app.t
@@ -26,19 +26,19 @@ get '/' => 'index';
 my $t = Test::Mojo->new;
 
 $t->get_ok('/')->status_is(200)
-  ->content_is("ПриветПривет дваru\n");
+  ->content_is("ПриветПривет дваrufailed_inexistent_key_in_lexicon\n");
 
 $t->get_ok('/ru')->status_is(200)
-  ->content_is("ПриветПривет дваru\n");
+  ->content_is("ПриветПривет дваrufailed_inexistent_key_in_lexicon\n");
 
 $t->get_ok('/en')->status_is(200)
-  ->content_is("helloHello twoen\n");
+  ->content_is("failed_helloHello twoenfailed_inexistent_key_in_lexicon\n");
 
 $t->get_ok('/de')->status_is(200)
-  ->content_is("ПриветПривет дваru\n");
+  ->content_is("ПриветПривет дваrufailed_inexistent_key_in_lexicon\n");
 
 $t->get_ok('/en-us')->status_is(200)
-  ->content_is("helloHello two USen-us\n");
+  ->content_is("helloHello two USen-usinexistent_key_in_lexicon\n");
 
 $t->get_ok('/es')->status_is(404);
 
@@ -46,4 +46,4 @@ done_testing;
 
 __DATA__
 @@ index.html.ep
-<%=l 'hello' %><%=l 'hello2' %><%= languages %>
+<%=l 'hello' %><%=l 'hello2' %><%= languages %><%=l 'inexistent_key_in_lexicon' %>

--- a/t/i18n_app_en_us.t
+++ b/t/i18n_app_en_us.t
@@ -32,7 +32,7 @@ $t->get_ok('/ru')->status_is(200)
   ->content_is("ПриветПривет дваru\n");
 
 $t->get_ok('/en')->status_is(200)
-  ->content_is("helloHello twoen\n");
+  ->content_is("failed_helloHello twoen\n");
 
 $t->get_ok('/de')->status_is(200)
   ->content_is("helloHello two USen-us\n");

--- a/t/i18n_lite_app.t
+++ b/t/i18n_lite_app.t
@@ -14,7 +14,7 @@ package MyTestApp::I18N::de;
 use Mojo::Base -strict;
 use base 'MyTestApp::I18N';
 
-our %Lexicon = (hello => 'hallo');
+our %Lexicon = ( _AUTO => 1, hello => 'hallo');
 
 # "Aw, he looks like a little insane drunken angel."
 package main;

--- a/t/i18n_shortcut_lite_app.t
+++ b/t/i18n_shortcut_lite_app.t
@@ -14,13 +14,13 @@ package MyTestApp::I18N::en;
 use Mojo::Base -strict;
 use base 'MyTestApp::I18N';
 
-our %Lexicon = (hello => 'Hello World');
+our %Lexicon = ( _AUTO => 1, hello => 'Hello World');
 
 package MyTestApp::I18N::de;
 use Mojo::Base -strict;
 use base 'MyTestApp::I18N';
 
-our %Lexicon = (hello => 'Hallo Welt');
+our %Lexicon = ( _AUTO => 1, hello => 'Hallo Welt');
 
 # "Planet Express - Our crew is replaceable, your package isn't."
 package main;


### PR DESCRIPTION
I just spent half of day trying to figure out why the fail handler for a Locale::Maketext package is not working. 

I think it is a bug in your plugin with $handle->fail_with(sub { $_[1] }); - it shouldn't be there.

However, I modified your tests in order to work with the modification and I hope you'll accept my pull request (this would be my first ever code contribution).