### PR TITLE
fix url_for api compatibility issues

### DIFF
--- a/lib/Mojolicious/Plugin/I18N.pm
+++ b/lib/Mojolicious/Plugin/I18N.pm
@@ -107,12 +107,17 @@ sub register {
 	my $mojo_url_for = *Mojolicious::Controller::url_for{CODE};
 	
 	my $i18n_url_for = sub {
-		my($self, $target, %params) = @_;
-		
-		my $url = $self->$mojo_url_for($target, %params);
+                my $self = shift;
+		my $url  = $self->$mojo_url_for(@_);
 		
 		# Absolute URL
 		return $url if $url->is_abs;
+
+                # Discard target if present
+                shift if (@_ % 2 && !ref $_[0]) || (@_ > 1 && ref $_[-1]);
+                
+                # Unveil params
+                my %params = @_ == 1 ? %{$_[0]} : @_;
 			
 		# Detect lang
 		if (my $lang = $params{lang} || $self->stash('lang')) {

--- a/t/i18n_url_for.t
+++ b/t/i18n_url_for.t
@@ -35,6 +35,7 @@ plugin 'I18N' => { namespace => 'App::I18N', default => 'ru', support_url_langs 
 
 get '/' => 'index';
 get '/auth' => 'auth';
+get '/test/:slug' => 'compat';
 
 post '/login' => sub {
   my $self = shift;
@@ -62,6 +63,9 @@ $t->get_ok('/de')->status_is(200)
   ->content_is("ПриветПривет дваru\n/de\n/de?test=1\n");
 
 $t->get_ok('/es')->status_is(404);
+
+$t->get_ok('/test/hello')->status_is(200)
+  ->content_is("/test/hello\n/en/test/hello\n/en/test/hello\n/en/test/hello\n/en/test/hello\n/en/perldoc\n//mojolicio.us/en/perldoc\nhttp://mojolicio.us/perldoc\nmailto:sri\@example.com\n");
 
 my $port = $t->tx->remote_port();
 
@@ -102,3 +106,14 @@ __DATA__
 
 @@ auth.html.ep
 <a href="http://example.com/widget?lang=<%= languages %>&token_url=<%= url_for('login')->query('next' => url_for 'auth')->to_abs() %>">auth</a>
+
+@@ compat.html.ep
+%= url_for
+%= url_for(slug => stash('slug'), lang => 'en')
+%= url_for({slug => stash('slug'), lang => 'en'})
+%= url_for('compat', slug => stash('slug'), lang => 'en')
+%= url_for('compat', {slug => stash('slug'), lang => 'en'})
+%= url_for('/perldoc', lang => 'en')
+%= url_for('//mojolicio.us/perldoc', lang => 'en')
+%= url_for('http://mojolicio.us/perldoc', lang => 'en')
+%= url_for('mailto:sri@example.com', lang => 'en')


### PR DESCRIPTION
Hey!

As of version 1.1, the url_for helper does not comply with the original interface, incorrectly capturing the passed-in arguments. e.g: passing a list, passing target + hashref...

I add some tests unveiling this issue and provide a fix.

Cheers
Alex
