### PR TITLE
Mojolicious 6.0 was released some days ago....

### DIFF
--- a/t/i18n_url_for.t
+++ b/t/i18n_url_for.t
@@ -48,7 +48,7 @@ post '/login' => sub {
 
 #
 
-like $Mojolicious::VERSION, qr/^5\.\d+$/, 'Check Mojolicious 5.0';
+cmp_ok $Mojolicious::VERSION, '>=', 5.0, 'Check Mojolicious >= 5.0';
 
 #
 


### PR DESCRIPTION
Now this plugin fails to install due to the check for Mojolicious 5.x. I don't know what this test is for, because there is no bailout or a skip when the Mojolicious version doesn't match...